### PR TITLE
Fix typo

### DIFF
--- a/src/main/docs/guide/writingTheApp/schedulingAJobManually.adoc
+++ b/src/main/docs/guide/writingTheApp/schedulingAJobManually.adoc
@@ -30,7 +30,7 @@ Create a runnable task `EmailTask.kt`
 include::{sourceDir}/src/main/kotlin/example/micronaut/EmailTask.kt[]
 ----
 
-Create `RegisterService.kt` which schedules the previous task.
+Create `RegisterUseCase.kt` which schedules the previous task.
 
 [source, kotlin]
 .src/main/kotlin/example/micronaut/RegisterUseCase.kt


### PR DESCRIPTION
Replaced `RegisterService.kt` with `ReigsterUseCase.kt` to align with the rest of the guide.